### PR TITLE
fix: keep .env in build contexts, exclude local overrides instead

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@ vendor/
 public/build/
 docker-*
 Dockerfile*
-.env
+.env.local
+.env.*.local


### PR DESCRIPTION
.env carries the committed defaults the application needs to boot (TRUSTED_PROXIES, CSRF_ENABLED, DEFAULT_URI, OAUTH_*) and ships in every release archive. Excluding it from build contexts made any image built from a working copy fail at "composer dump-env prod" and produced a container that could not boot the kernel.